### PR TITLE
Added creating tar.gz archives of the binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,15 @@
 language: go
 go:
   - 1.9
+before_deploy:
+  - go get github.com/mitchellh/gox
+  - mkdir releases
+  - gox -output="releases/{{.Dir}}_{{.OS}}_{{.Arch}}/{{.Dir}}"
+  - find releases -maxdepth 1 -mindepth 1 -type d -exec tar -cvzf {}.tar.gz {} \;
+deploy:
+  provider: releases
+  api_key: "CHANGE_IT"
+  file: "releases/*tar.gz"
+  skip_cleanup: true
+  on:
+    tags: true


### PR DESCRIPTION
Hi @monochromata, I had some time left, so I tried to help you a bit. In my opinion it should now work when the `api_key` is set.
With this commit the binaries were built with gox and packed into an archive (tar.gz). After that they were deployed to GitHub releases only when a new tag is pushed to the origin. (tag name = release version)